### PR TITLE
Syntax highlighting, aspecto de termimnal a los codeblock y smoothscroll

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -5,23 +5,32 @@ import starlight from "@astrojs/starlight";
 export default defineConfig({
   integrations: [
     starlight({
+      expressiveCode: {
+        themes: ["github-dark-dimmed", "solarized-light"], //Temas de syntax highlighting (Bloques de código)
+        styleOverrides: {
+          borderRadius: "0.5rem", //Bordes redondeados en los bloques de código
+        },
+      },
       title: "Jetpack Compose Pro",
       locales: {
         root: {
-          label: 'Español',
-          lang: 'es',
+          label: "Español",
+          lang: "es",
         },
-      },      description: "La mayor base de datos de Jetpack Compose de habla hispana.",
+      },
+      description:
+        "La mayor base de datos de Jetpack Compose de habla hispana.",
       editLink: {
-        baseUrl: 'https://github.com/ArisGuimera/JetpackComposePro/blob/master/'
+        baseUrl:
+          "https://github.com/ArisGuimera/JetpackComposePro/blob/master/",
       },
       social: {
         github: "https://github.com/ArisGuimera/JetpackComposePro",
-        youtube: 'https://youtube.com/@aristidevs',
-        discord: 'https://bit.ly/3bmeQvm',
+        youtube: "https://youtube.com/@aristidevs",
+        discord: "https://bit.ly/3bmeQvm",
         twitter: "https://x.com/aristidevs",
-        linkedin: 'https://www.linkedin.com/in/aristides-guimera-orozco/',
-        twitch: 'https://www.twitch.tv/aristidevs',
+        linkedin: "https://www.linkedin.com/in/aristides-guimera-orozco/",
+        twitch: "https://www.twitch.tv/aristidevs",
       },
       sidebar: [
         {
@@ -111,7 +120,7 @@ export default defineConfig({
         {
           label: "ToolTips",
           autogenerate: { directory: "tooltips" },
-        }
+        },
       ],
     }),
   ],

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -11,6 +11,9 @@ export default defineConfig({
           borderRadius: "0.5rem", //Bordes redondeados en los bloques de código
         },
       },
+      customCss: [
+        './src/styles/smoothscroll.css', //Para que el scroll sea suave entre secciones
+      ],
       title: "Jetpack Compose Pro",
       locales: {
         root: {

--- a/src/content/docs/badges/badge.mdx
+++ b/src/content/docs/badges/badge.mdx
@@ -20,7 +20,7 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
 <Tabs>
 <TabItem label="Material">
 
-```kotlin
+```kotlin frame="terminal"
 @Composable
 fun Badge(
     modifier: Modifier = Modifier,
@@ -38,7 +38,7 @@ fun Badge(
 </TabItem>
 <TabItem label="Material 3">
 
-```kotlin
+```kotlin frame="terminal"
 @ExperimentalMaterial3Api
 @Composable
 fun Badge(
@@ -69,7 +69,7 @@ Puedes acceder a la documentación oficial de Google
 <Tabs>
 <TabItem label="Material">
 
-```kotlin
+```kotlin frame="terminal"
 @Composable
 fun Text(
     text: String,
@@ -82,7 +82,7 @@ fun Text(
 </TabItem>
 <TabItem label="Material 3">
 
-```kotlin
+```kotlin frame="terminal"
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun BadgeExample() {

--- a/src/content/docs/badges/badged-box.mdx
+++ b/src/content/docs/badges/badged-box.mdx
@@ -20,7 +20,7 @@ import { Tabs, TabItem } from "@astrojs/starlight/components";
 <Tabs>
 <TabItem label="Material">
 
-```kotlin
+```kotlin frame="terminal"
 @Composable
 fun BadgedBox(
     badge: @Composable BoxScope.() -> Unit,
@@ -37,7 +37,7 @@ fun BadgedBox(
 
 <TabItem label="Material 3">
 
-```kotlin
+```kotlin frame="terminal"
 @ExperimentalMaterial3Api
 @Composable
 fun BadgedBox(
@@ -65,7 +65,7 @@ Puedes acceder a la documentación oficial de Google
 <Tabs>
 <TabItem label="Material">
 
-```kotlin
+```kotlin frame="terminal"
 @Composable
 fun BadgedBoxExample() {
     Box(Modifier.size(100.dp), contentAlignment = Alignment.Center) {
@@ -82,7 +82,7 @@ fun BadgedBoxExample() {
 </TabItem>
 <TabItem label="Material 3">
 
-```kotlin
+```kotlin frame="terminal"
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun BadgedBoxExample() {

--- a/src/content/docs/text/text.mdx
+++ b/src/content/docs/text/text.mdx
@@ -22,7 +22,7 @@ Text es el componente más básico a la hora de trabajar con Jetpack Compose, no
 <Tabs>
 <TabItem label="Material">
 
-```kotlin
+```kotlin frame="terminal"
 @Composable
 fun Text(
     text: String,
@@ -40,7 +40,7 @@ fun Text(
 </TabItem>
 <TabItem label="Material 3">
 
-```kotlin
+```kotlin frame="terminal"
 @Composable
 fun Text(
     text: String,

--- a/src/styles/smoothscroll.css
+++ b/src/styles/smoothscroll.css
@@ -1,0 +1,3 @@
+html {
+    scroll-behavior: smooth;
+}


### PR DESCRIPTION
## PR (parte de #1)

- Añadido propiedades a la librería `expressive-code` que viene implementada en Astro para que use el colorido de GitHub en modo oscuro de la página y otro que me gustó para el modo claro. Como se puede ver en el código son los siguientes:
```
 themes: ["github-dark-dimmed", "solarized-light"]
```
[Aquí](https://github.com/expressive-code/expressive-code/blob/main/packages/astro-expressive-code/README.md#themes) hay una lista con todos los temas disponibles, y si no estoy equivocado, podemos crear los nuestros con CSS.
- Añadido el estilo de terminal (los botoncitos encima de los bloques de código) que hablaste en el directo (sí, me lo he estado viendo el resubido un poco porque no pude estar).
- Smooth scroll entre secciones de los componentes
### Como se vé
<img width="569" alt="image" src="https://github.com/ArisGuimera/JetpackComposePro/assets/60316747/78c96f17-dacc-4f54-8eb2-bbe9d10669cb">
