### PR TITLE
fix guide screen show images in prod

### DIFF
--- a/src/components/ExpandLinkCard.astro
+++ b/src/components/ExpandLinkCard.astro
@@ -3,13 +3,30 @@
 
 // import type { HTMLAttributes } from 'astro/types';
 
+import dialogIMG from "../assets/alertDialog/alertDialog-header-ExampleMaterial3.webp";
+import chipIMG from "../assets/chip/assist-chip/chip-assist-material-3-example.webp"; 
+import buttonIMG from "../assets/buttons/button/button-header-material-3.png"; 
+import appBarIMG from "../assets/appbars/bottomappbar/bottomappbar-header-material-3.png"; 
+import badgeIMG from "../assets/badges/badge/badge-header-material-3.png"; 
+import switchIMG from "../assets/switch/switch-header.webp"; 
+
 interface Props {
   title: string;
   description?: string;
-  imagePath?: string;
 }
 
-const { title, description, imagePath, ...attributes } = Astro.props;
+const { title, description, ...attributes } = Astro.props;
+
+const imageMapping: { [key: string]: string } = {
+  "Dialogs": dialogIMG.src,
+  "Chips": chipIMG.src,
+  "Buttons": buttonIMG.src,
+  "App Bars": appBarIMG.src,
+  "Badges": badgeIMG.src,
+  "Switch": switchIMG.src
+};
+
+const imagePath = imageMapping[title]
 ---
 
 <div>

--- a/src/content/docs/home/guide.mdx
+++ b/src/content/docs/home/guide.mdx
@@ -17,126 +17,105 @@ Jetpack Compose es la nueva forma de crear vistas en Android utilizando únicame
     title="App Bars"
     description="Barras de herramientas que proporcionan funciones de naveción y acciones."
     href="/app-bars/bottom-app-bar/"
-    imagePath="../../src/assets/appbars/bottomappbar/bottomappbar-header-material-3.png"
   />
     <ExpandLinkCard
     title="Badges"
     description="La forma de representar notificaciones en Android."
     href="/badges/badge/"
-    imagePath="../../src/assets/badges/badge/badge-header-material-3.png"
   />
     <ExpandLinkCard
     title="Buttons"
     description="Componentes para realizar acciones."
     href="/buttons/button/"
-    imagePath="../../src/assets/buttons/button/button-header-material-3.png"
   />
     <ExpandLinkCard
     title="Cards"
     description="Representan información de una forma estructurada y organizada."
     href="/cards/card/"
-    imagePath=""
   />
     <ExpandLinkCard
     title="Carousel"
     description="Permiten al usuario desplazar información horizontal o verticalmente."
     href="/carousel/carousel/"
-    imagePath=""
   />
     <ExpandLinkCard
     title="Checkbox"
     description="Elementos interactivos para marcar o desmarcar una opción."
     href="/checkbox/checkbox/"
-    imagePath=""
   />
     <ExpandLinkCard
     title="Chips"
     description="Vistas compactas que representan acciones o información específica."
     href="/chips/assist-chip/"
-    imagePath="../../src/assets/chip/assist-chip/chip-assist-material-3-example.webp"
   />
     <ExpandLinkCard
     title="Pickers"
     description="Permiten al usuario seleccionar un valor entre un conjunto predefinido."
     href="/pickers/date-picker/"
-    imagePath=""
   />
     <ExpandLinkCard
     title="Dialogs"
     description="Ventanas emergentes para mostrar información adicional."
     href="/dialogs/alert-dialog/"
-    imagePath="../../src/assets/alertDialog/alertDialog-header-ExampleMaterial3.webp"
   />
     <ExpandLinkCard
     title="Dividers"
     description="Separador visual para delimitar elementos."
     href="/divider/divider/"
-    imagePath=""
   />
     <ExpandLinkCard
     title="Lists"
     description="Listados horizontales o verticales que muestran información de una forma optimizada."
     href="/lists/lazy-column/"
-    imagePath=""
   />
     <ExpandLinkCard
     title="Menus"
     description="Proporcionan listas de acciones predeterminadas."
     href="/menus/dropdown-menu-item/"
-    imagePath=""
   />
     <ExpandLinkCard
     title="Progress Indicators"
     description="Elementos que notifican al usuario que se está realizando una acción."
     href="/progress-indicator/circular-progress-indicator/"
-    imagePath=""
   />
     <ExpandLinkCard
     title="Sheets"
     description="Listas de acciones predeterminadas de una manera modal."
     href="/sheets/bottom-sheet/"
-    imagePath=""
   />
     <ExpandLinkCard
     title="Sliders"
     description="Controles deslizantes que permiten al usuario seleccionar un valor entre un determinado rango."
     href="/sliders/section-slider/"
-    imagePath=""
   />
     <ExpandLinkCard
     title="Snackbars"
     description="Proporcionan mensajes breves y temporales."
     href="/snackbar/snackbar/"
-    imagePath=""
   />
     <ExpandLinkCard
     title="Switch"
     description="Componentes de estado que permiten alternan entre ON y OFF."
     href="/switch/switch/"
-    imagePath="../../src/assets/switch/switch-header.webp"
   />
     <ExpandLinkCard
     title="Tabs"
     description="Organizar el contenido de las vistas en diferentes pantallas desde un mismo lugar."
     href="/tabs/tab/"
-    imagePath=""
   />
     <ExpandLinkCard
     title="Texts"
     description="Componente principal para mostrar textos en las vistas."
     href="/text/text/"
-    imagePath=""
   />
     <ExpandLinkCard
     title="Texts Fields"
     description="Permiten al usuario ingresar y editar textos en las aplicaciones."
     href="/text-fields/text-field/"
-    imagePath=""
   />
     <ExpandLinkCard
     title="Tooltips"
     description="Cuadro informativo usados habitualmente a modo de tutorial."
     href="/tooltips/plain-tooltip/"
-    imagePath=""
   />
 </CardGrid>


### PR DESCRIPTION
# Cambios 🚀:
Buenas Aris @ArisGuimera  investigando me encontré que al utilizar las carpetas assets astro optimiza la imagen y con ello la ubicación del mismo cambia :

### Código de ejemplo en local

```
---
// import the Image component and the image
import myImage from "../assets/my_image.png";
---

// alt is mandatory on the Image component
<img src={myImage} alt="A description of my image." />
```

### IMG cuando esta prod:

```
<img
  src="/_astro/my_image.hash.webp"
  width="1600"
  height="900"
  decoding="async"
  loading="lazy"
  alt="A description of my image."
/>
```

Fuente: [link](https://markjames.dev/blog/dynamically-importing-images-astro)
Por ello cambie el componente `ExpandLinkCard` un poco (intente que sea lo mas limpio posible):
Elimine el atributo **imagePath** para no ser redundante y utilizar el atributo del card `title` para poner la imagen envase al `imageMapping` y los imports previamente importandos el propio component.

Resultado:
![image](https://github.com/ArisGuimera/JetpackComposePro/assets/57275367/ed87b1be-913f-49c9-b4b6-7606601f2f28)


Aguardo cualquier feedback 🚀.

