### PR TITLE
Replace BottomNavigationItem with NavigationBarItem in Material 3

### DIFF
--- a/src/content/docs/app-bars/bottom-navigation.mdx
+++ b/src/content/docs/app-bars/bottom-navigation.mdx
@@ -157,25 +157,25 @@ fun BottomNavigationExample() {
 @Composable
 fun NavigationBarExample() {
     NavigationBar( windowInsets = NavigationBarDefaults.windowInsets ){
-        BottomNavigationItem(
+        NavigationBarItem(
             selected = true,
             onClick = { /*TODO*/ },
             icon = { Icon( Icons.Filled.Favorite, null) },
             label = { Text(text = "Aris")}
         )
-        BottomNavigationItem(
+        NavigationBarItem(
             selected = false,
             onClick = { /*TODO*/ },
             icon = { Icon( Icons.Filled.Favorite, null) },
             label = { Text(text = "Aris")}
         )
-        BottomNavigationItem(
+        NavigationBarItem(
             selected = false,
             onClick = { /*TODO*/ },
             icon = { Icon( Icons.Filled.Favorite, null) },
             label = { Text(text = "Aris")}
         )
-        BottomNavigationItem(
+        NavigationBarItem(
             selected = true,
             onClick = { /*TODO*/ },
             icon = { Icon( Icons.Filled.Favorite, null) },


### PR DESCRIPTION
Hola, corregí esta clase que no pertenece a NavigationBar en Material 3. Lo probé en un proyecto personal y funciona correctamente

`Material  -> BottomNavigationBar -> BottomNavigationItem`
`Material 3 -> NavigationBar -> NavigationBarItem`